### PR TITLE
Fixed master branch issue

### DIFF
--- a/.github/workflows/mocha.yml
+++ b/.github/workflows/mocha.yml
@@ -1,9 +1,9 @@
 name: CI
 on:
     push:
-        branches: [master, dev, quality]
+        branches: [main, dev, quality]
     pull_request:
-        branches: [master, dev, quality]
+        branches: [main, dev, quality]
 
 jobs:
     verify_files:


### PR DESCRIPTION
CI runs on `push` and `pull_request` for `master`, but github recently changed default branch names to `main`. I made the switch